### PR TITLE
Decode sets as MapSet

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -8,6 +8,11 @@ config :ex_aws, :dynamodb,
   port: 8000,
   region: "us-east-1"
 
+case Mix.env do
+  :test_options -> import_config "test_options.exs"
+  _             -> nil
+end
+
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/config/test_options.exs
+++ b/config/test_options.exs
@@ -1,0 +1,5 @@
+use Mix.Config
+require Logger
+
+config :ex_aws, :dynamodb,
+  decode_sets: true

--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -123,6 +123,14 @@ defmodule ExAws.Dynamo do
   |> ExAws.request!
   |> Dynamo.decode_item(as: User)
   ```
+
+  By default this will decode various dynamodb sets into lists. If you'd
+  prefer they be decoded into `MapSet`s instead, set `decode_sets: true` in
+  your compile-time (not runtime) configuration:
+
+  ```elixir
+  config :ex_aws, :dynamodb, decode_sets: true
+  ```
   """
   @spec decode_item(Map.t()) :: Map.t()
   @spec decode_item(Map.t(), as: atom) :: Map.t()

--- a/lib/ex_aws/dynamo/decoder.ex
+++ b/lib/ex_aws/dynamo/decoder.ex
@@ -31,11 +31,13 @@ defmodule ExAws.Dynamo.Decoder do
   def decode(%{"B" => value}), do: value
   def decode(%{"S" => value}), do: value
   def decode(%{"M" => value}), do: value |> decode
-  def decode(%{"SS" => values}), do: values
+  def decode(%{"SS" => values}), do: MapSet.new(values)
   def decode(%{"BS" => values}), do: values
 
   def decode(%{"NS" => values}) do
-    Enum.map(values, &binary_to_number/1)
+    values
+    |> Stream.map(&binary_to_number/1)
+    |> Enum.into(MapSet.new())
   end
 
   def decode(%{"L" => values}) do

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,8 @@ defmodule ExAws.Dynamo.Mixfile do
       deps: deps(),
       name: @name,
       package: package(),
-      docs: [main: @name, source_ref: "v#{@version}", source_url: @url]
+      docs: [main: @name, source_ref: "v#{@version}", source_url: @url],
+      aliases: aliases()
     ]
   end
 
@@ -31,6 +32,7 @@ defmodule ExAws.Dynamo.Mixfile do
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(:test_options), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
   # Run "mix help compile.app" to learn about applications.
@@ -44,9 +46,9 @@ defmodule ExAws.Dynamo.Mixfile do
   defp deps do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:hackney, ">= 0.0.0", only: [:dev, :test]},
-      {:sweet_xml, ">= 0.0.0", only: [:dev, :test]},
-      {:poison, ">= 0.0.0", only: [:dev, :test]},
+      {:hackney, ">= 0.0.0", only: [:dev, :test, :test_options]},
+      {:sweet_xml, ">= 0.0.0", only: [:dev, :test, :test_options]},
+      {:poison, ">= 0.0.0", only: [:dev, :test, :test_options]},
       ex_aws()
     ]
   end
@@ -56,5 +58,27 @@ defmodule ExAws.Dynamo.Mixfile do
       "LOCAL" -> {:ex_aws, path: "../ex_aws"}
       _ -> {:ex_aws, "~> 2.0"}
     end
+  end
+
+  defp aliases do
+    [
+      {:"test.all", [&run_tests/1, "test.options"]},
+      {:"test.options", [&run_options_tests/1]}
+    ]
+  end
+
+  defp run_tests(_) do
+    Mix.shell.cmd(
+      "mix test --color",
+      env: [{"MIX_ENV", "test"}]
+    )
+  end
+
+  defp run_options_tests(_) do
+    IO.puts "\nRunning tests with options enabled."
+    Mix.shell.cmd(
+      "mix test --color",
+      env: [{"MIX_ENV", "test_options"}]
+    )
   end
 end

--- a/test/lib/dynamo/decoder_test.exs
+++ b/test/lib/dynamo/decoder_test.exs
@@ -5,10 +5,15 @@ defmodule ExAws.Dynamo.DecoderTest do
 
   test "decoder works on lists of numbers" do
     assert %{"NS" => ["1", "2", "3"]}
-           |> Decoder.decode() == [1, 2, 3]
+           |> Decoder.decode() == MapSet.new([1, 2, 3])
 
     assert %{"NS" => [1, 2, 3]}
-           |> Decoder.decode() == [1, 2, 3]
+           |> Decoder.decode() == MapSet.new([1, 2, 3])
+  end
+
+  test "decoder decodes stringset to a mapset" do
+    assert %{"SS" => ["foo", "bar", "baz"]}
+      |> Decoder.decode() == MapSet.new(["foo", "bar", "baz"])
   end
 
   test "lists of different types" do

--- a/test/lib/dynamo/decoder_test.exs
+++ b/test/lib/dynamo/decoder_test.exs
@@ -3,17 +3,42 @@ defmodule ExAws.Dynamo.DecoderTest do
   alias ExAws.Dynamo.Decoder
   alias ExAws.Dynamo.Encoder
 
-  test "decoder works on lists of numbers" do
-    assert %{"NS" => ["1", "2", "3"]}
-           |> Decoder.decode() == MapSet.new([1, 2, 3])
+  if Application.get_env(:ex_aws, :dynamodb, [])[:decode_sets] do
+    test "decoder decodes numberset to a mapset of numbers" do
+      assert %{"NS" => ["1", "2", "3"]}
+            |> Decoder.decode() == MapSet.new([1, 2, 3])
 
-    assert %{"NS" => [1, 2, 3]}
-           |> Decoder.decode() == MapSet.new([1, 2, 3])
-  end
+      assert %{"NS" => [1, 2, 3]}
+            |> Decoder.decode() == MapSet.new([1, 2, 3])
+    end
 
-  test "decoder decodes stringset to a mapset" do
-    assert %{"SS" => ["foo", "bar", "baz"]}
-      |> Decoder.decode() == MapSet.new(["foo", "bar", "baz"])
+    test "decoder decodes stringset to a mapset of strings" do
+      assert %{"SS" => ["foo", "bar", "baz"]}
+        |> Decoder.decode() == MapSet.new(["foo", "bar", "baz"])
+    end
+
+    test "decoder decodes binaryset to a mapset of strings" do
+      assert %{"BS" => ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]}
+        |> Decoder.decode() == MapSet.new(["U3Vubnk=", "UmFpbnk=", "U25vd3k="])
+    end
+  else
+    test "decoder decodes numberset to a list of numbers" do
+      assert %{"NS" => ["1", "2", "3"]}
+            |> Decoder.decode() == [1, 2, 3]
+
+      assert %{"NS" => [1, 2, 3]}
+            |> Decoder.decode() == [1, 2, 3]
+    end
+
+    test "decoder decodes stringset to a list of strings" do
+      assert %{"SS" => ["foo", "bar", "baz"]}
+        |> Decoder.decode() == ["foo", "bar", "baz"]
+    end
+
+    test "decoder decodes binaryset to a list of strings" do
+      assert %{"BS" => ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]}
+        |> Decoder.decode() == ["U3Vubnk=", "UmFpbnk=", "U25vd3k="]
+    end
   end
 
   test "lists of different types" do


### PR DESCRIPTION
MapSet encodes to either a dynamo stringset (SS) or number set (NS). When decoding, they currently decode to a list. Wouldn't it be more natural if they decoded to a MapSet? That is what this PR does.