### PR TITLE
Add support for list of items while decoding

### DIFF
--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -125,6 +125,10 @@ defmodule ExAws.Dynamo do
   @spec decode_item(Map.t(), as: atom) :: Map.t()
   def decode_item(item, opts \\ [])
 
+  def decode_item(%{"Items" => items}, opts) do
+    for item <- items, do: decode_item(item, opts)
+  end
+
   def decode_item(%{"Item" => item}, opts) do
     decode_item(item, opts)
   end


### PR DESCRIPTION
## Description of issue

In the following scenario: 
```elixir
Dynamo.scan("SeveralUsers", limit: 2)
|> ExAws.request!()
|> Dynamo.decode_item(as: Test.User)
```
When decoding more than one item, a matching error is raised, because DynamoDB returns the key `"Items"` instead of `"Item"`.

## Given solution

Alongside with an integration test, a new match is added for matching the key `"Items"`.