### PR TITLE
add DynamoDb transaction API calls

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,7 @@
+[
+  # files to format
+  inputs: ["mix.exs", "{config,lib,test,priv}/**/*.{ex,exs}"],
+  locals_without_parens: [config: 0],
+  line_length: 120,
+  rename_deprecated_at: "1.6.1"
+]

--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -630,7 +630,7 @@ defmodule ExAws.Dynamo do
   end
 
   defp build_transaction_item(method, table_name, item, opts) do
-    item = item |> Map.new() |> Dynamo.Encoder.encode_root()
+    item = item |> Dynamo.Encoder.encode_root()
 
     details =
       opts

--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -60,7 +60,7 @@ defmodule ExAws.Dynamo do
   http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Operations.html
   """
 
-  import ExAws.Utils, only: [camelize_keys: 1, camelize_keys: 2, upcase: 1]
+  import ExAws.Utils, only: [camelize: 1, camelize_keys: 1, camelize_keys: 2, upcase: 1]
   alias __MODULE__
 
   @nested_opts [:exclusive_start_key, :expression_attribute_values, :expression_attribute_names]
@@ -272,8 +272,7 @@ defmodule ExAws.Dynamo do
   end
 
   @doc "Update time to live"
-  @spec update_time_to_live(table :: binary, ttl_attribute :: binary, enabled :: boolean) ::
-          ExAws.Operation.JSON.t()
+  @spec update_time_to_live(table :: binary, ttl_attribute :: binary, enabled :: boolean) :: ExAws.Operation.JSON.t()
   def update_time_to_live(table, ttl_attribute, enabled) do
     data = %{
       "TableName" => table,
@@ -416,8 +415,7 @@ defmodule ExAws.Dynamo do
           | {:keys, [primary_key]}
         ]
   @spec batch_get_item(%{table_name => get_item}) :: ExAws.Operation.JSON.t()
-  @spec batch_get_item(%{table_name => get_item}, opts :: batch_get_item_opts) ::
-          ExAws.Operation.JSON.t()
+  @spec batch_get_item(%{table_name => get_item}, opts :: batch_get_item_opts) :: ExAws.Operation.JSON.t()
   def batch_get_item(data, opts \\ []) do
     request_items =
       data
@@ -455,8 +453,7 @@ defmodule ExAws.Dynamo do
           | {:return_values, return_values_vals}
         ]
   @spec put_item(table_name :: table_name, record :: map()) :: ExAws.Operation.JSON.t()
-  @spec put_item(table_name :: table_name, record :: map(), opts :: put_item_opts) ::
-          ExAws.Operation.JSON.t()
+  @spec put_item(table_name :: table_name, record :: map(), opts :: put_item_opts) :: ExAws.Operation.JSON.t()
   def put_item(name, record, opts \\ []) do
     data =
       opts
@@ -487,8 +484,7 @@ defmodule ExAws.Dynamo do
           | {:return_item_collection_metrics, return_item_collection_metrics_vals}
         ]
   @spec batch_write_item(%{table_name => [write_item]}) :: ExAws.Operation.JSON.t()
-  @spec batch_write_item(%{table_name => [write_item]}, opts :: batch_write_item_opts) ::
-          ExAws.Operation.JSON.t()
+  @spec batch_write_item(%{table_name => [write_item]}, opts :: batch_write_item_opts) :: ExAws.Operation.JSON.t()
   def batch_write_item(data, opts \\ []) do
     request_items =
       data
@@ -577,8 +573,7 @@ defmodule ExAws.Dynamo do
           | {:return_item_collection_metrics, return_item_collection_metrics_vals}
           | {:return_values, return_values_vals}
         ]
-  @spec delete_item(table_name :: table_name, primary_key :: primary_key) ::
-          ExAws.Operation.JSON.t()
+  @spec delete_item(table_name :: table_name, primary_key :: primary_key) :: ExAws.Operation.JSON.t()
   @spec delete_item(
           table_name :: table_name,
           primary_key :: primary_key,
@@ -594,6 +589,103 @@ defmodule ExAws.Dynamo do
       })
 
     request(:delete_item, data)
+  end
+
+  @doc """
+  Update item in table
+
+  For update_args format see
+  http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateItem.html
+  """
+  @type transact_get_item_opts :: [
+          {:expression_attribute_names, expression_attribute_names_vals}
+          | {:projection_expression, binary}
+        ]
+
+  @type transact_get_item ::
+          {table_name :: binary, primary_key :: primary_key}
+          | {table_name :: binary, primary_key :: primary_key, transact_get_item_opts}
+
+  @type transact_get_items_opts :: [
+          {:return_consumed_capacity, return_consumed_capacity_vals}
+        ]
+
+  @spec transact_get_items(items :: [transact_get_item], transact_get_items_opts) :: ExAws.Operation.JSON.t()
+  @spec transact_get_items(items :: [transact_get_item]) :: ExAws.Operation.JSON.t()
+  def transact_get_items(items, opts \\ []) do
+    data =
+      opts
+      |> build_opts
+      |> Map.merge(%{
+        "TransactItems" => Enum.map(items, &build_transaction_item({:get, &1}))
+      })
+
+    request(:transact_get_items, data)
+  end
+
+  defp build_transaction_item({method, {table, item}}), do: build_transaction_item({method, {table, item, []}})
+
+  defp build_transaction_item({method, {table, item, opts}}) do
+    build_transaction_item(method, table, item, opts)
+  end
+
+  defp build_transaction_item(method, table_name, item, opts) do
+    item = item |> Map.new() |> Dynamo.Encoder.encode_root()
+
+    details =
+      opts
+      |> build_opts()
+      |> Map.merge(%{
+        "TableName" => table_name,
+        transaction_item_key(method) => item
+      })
+
+    %{camelize(method) => details}
+  end
+
+  defp transaction_item_key(:put), do: "Item"
+  defp transaction_item_key(_any), do: "Key"
+
+  @type return_values_on_condition_check_failure_vals :: :all_old | :none
+
+  @type transact_standard_item_opts :: [
+          {:condition_expression, binary}
+          | {:expression_attribute_names, expression_attribute_names_vals}
+          | {:expression_attribute_values, expression_attribute_values_vals}
+          | {:return_values_on_condition_check_failure, return_values_on_condition_check_failure_vals}
+        ]
+
+  @type transact_update_item_opts :: [
+          {:condition_expression, binary}
+          | {:expression_attribute_names, expression_attribute_names_vals}
+          | {:expression_attribute_values, expression_attribute_values_vals}
+          | {:return_values_on_condition_check_failure, return_values_on_condition_check_failure_vals}
+          | {:update_expression, binary}
+        ]
+
+  @type transact_write_item ::
+          {:condition_check, {table_name :: binary, key :: primary_key, transact_standard_item_opts}}
+          | {:delete, {table_name :: binary, key :: primary_key, transact_standard_item_opts}}
+          | {:put, {table_name :: binary, item :: map(), transact_standard_item_opts}}
+          | {:update, {table_name :: binary, key :: primary_key, transact_update_item_opts}}
+
+  @type transact_write_items_opts :: [
+          {:client_request_token, binary}
+          | {:return_consumed_capacity, return_consumed_capacity_vals}
+          | {:return_item_collection_metrics, return_item_collection_metrics_vals}
+        ]
+
+  @spec transact_write_items(items :: [transact_write_item], transact_write_items_opts) :: ExAws.Operation.JSON.t()
+  @spec transact_write_items(items :: [transact_write_item]) :: ExAws.Operation.JSON.t()
+  def transact_write_items(items, opts \\ []) do
+    data =
+      opts
+      |> build_opts
+      |> Map.merge(%{
+        "TransactItems" => Enum.map(items, &build_transaction_item/1)
+      })
+
+    request(:transact_write_items, data)
   end
 
   ## Options builder

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,8 @@
-%{"certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
+%{
+  "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ex_aws": {:hex, :ex_aws, "2.0.0", "9c83ca070b7ddc1079e61a07ba8d97d9c335888881f841bd54691d34fbf0e116", [:mix], [{:configparser_ex, "~> 2.0", [hex: :configparser_ex, repo: "hexpm", optional: true]}, {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6 or ~> 1.9", [hex: :hackney, repo: "hexpm", optional: true]}, {:jsx, "~> 2.8", [hex: :jsx, repo: "hexpm", optional: true]}, {:poison, ">= 1.2.0", [hex: :poison, repo: "hexpm", optional: true]}, {:sweet_xml, "~> 0.6", [hex: :sweet_xml, repo: "hexpm", optional: true]}, {:xml_builder, "~> 0.1.0", [hex: :xml_builder, repo: "hexpm", optional: true]}], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.9.0", "51c506afc0a365868469dcfc79a9d0b94d896ec741cfd5bd338f49a5ec515bfe", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
@@ -9,4 +10,5 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "sweet_xml": {:hex, :sweet_xml, "0.6.5", "dd9cde443212b505d1b5f9758feb2000e66a14d3c449f04c572f3048c66e6697", [:mix], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
+}

--- a/test/lib/dynamo/integration_test.exs
+++ b/test/lib/dynamo/integration_test.exs
@@ -62,8 +62,7 @@ defmodule ExAws.DynamoIntegrationTest do
   end
 
   test "put and get several items with map values work" do
-    {:ok, _} =
-      Dynamo.create_table("SeveralUsers", :email, [email: :string], 1, 1) |> ExAws.request()
+    {:ok, _} = Dynamo.create_table("SeveralUsers", :email, [email: :string], 1, 1) |> ExAws.request()
 
     user1 = %Test.User{
       email: "foo@bar.com",

--- a/test/lib/dynamo_test.exs
+++ b/test/lib/dynamo_test.exs
@@ -225,4 +225,57 @@ defmodule ExAws.DynamoTest do
     assert Enum.at(request.headers, 0) == {"x-amz-target", "DynamoDB_20120810.DescribeTimeToLive"}
     assert request.data == expected
   end
+
+  test "transact_get_items" do
+    expected = %{
+      "TransactItems" => [
+        %{
+          "Get" => %{
+            "Key" => %{"email" => %{"S" => "foo@baz.com"}},
+            "TableName" => "Users",
+            "ProjectionExpression" => "email,age"
+          }
+        }
+      ]
+    }
+
+    request =
+      Dynamo.transact_get_items([
+        {"Users", %{"email" => "foo@baz.com"}, projection_expression: "email,age"}
+      ])
+
+    assert Enum.at(request.headers, 0) == {"x-amz-target", "DynamoDB_20120810.TransactGetItems"}
+    assert request.data == expected
+  end
+
+  test "transact_write_items" do
+    expected = %{
+      "TransactItems" => [
+        %{
+          "Update" => %{
+            "ConditionExpression" => "Likes = :old_likes",
+            "ExpressionAttributeValues" => %{
+              ":likes" => %{"N" => "9"},
+              ":old_likes" => %{"N" => "99"}
+            },
+            "Key" => %{"email" => %{"S" => "foo@baz.com"}},
+            "TableName" => "Users",
+            "UpdateExpression" => "set Likes = :likes"
+          }
+        }
+      ]
+    }
+
+    request =
+      Dynamo.transact_write_items(
+        update:
+          {"Users", %{"email" => "foo@baz.com"},
+           update_expression: "set Likes = :likes",
+           condition_expression: "Likes = :old_likes",
+           expression_attribute_values: [likes: 9, old_likes: 99]}
+      )
+
+    assert Enum.at(request.headers, 0) == {"x-amz-target", "DynamoDB_20120810.TransactWriteItems"}
+    assert request.data == expected
+  end
 end


### PR DESCRIPTION
Added support for the new transaction API calls https://aws.amazon.com/blogs/aws/new-amazon-dynamodb-transactions/

I'm not super in love with the tuple syntax, and am definitely open to suggestions. I was trying to avoid the pattern the other SDKs use of having to call a function to build each transaction item.

DynamoDbLocal doesn't appear to have been updated yet with the new endpoints.