### PR TITLE
Properly handle Binary fields

### DIFF
--- a/lib/ex_aws/dynamo/decoder.ex
+++ b/lib/ex_aws/dynamo/decoder.ex
@@ -28,7 +28,7 @@ defmodule ExAws.Dynamo.Decoder do
   def decode(%{"BOOL" => "false"}), do: false
   def decode(%{"NULL" => true}), do: nil
   def decode(%{"NULL" => "true"}), do: nil
-  def decode(%{"B" => value}), do: value
+  def decode(%{"B" => value}), do: Base.decode64!(value)
   def decode(%{"S" => value}), do: value
   def decode(%{"M" => value}), do: value |> decode
   def decode(%{"SS" => values}), do: values

--- a/lib/ex_aws/dynamo/encodable.ex
+++ b/lib/ex_aws/dynamo/encodable.ex
@@ -94,7 +94,11 @@ end
 
 defimpl ExAws.Dynamo.Encodable, for: BitString do
   def encode(val, _) do
-    %{"S" => val}
+    if String.valid?(val) do
+      %{"S" => val}
+    else
+      %{"B" => Base.encode64(val)}
+    end
   end
 end
 

--- a/test/lib/dynamo/decoder_test.exs
+++ b/test/lib/dynamo/decoder_test.exs
@@ -35,4 +35,12 @@ defmodule ExAws.Dynamo.DecoderTest do
     user = %Test.User{email: "foo@bar.com", name: "Bob", age: 23, admin: false}
     assert user == user |> Encoder.encode() |> Decoder.decode(as: Test.User)
   end
+
+  test "Decoder binary that are not strings works" do
+    assert :zlib.unzip(
+             Decoder.decode(%{
+               "B" => "BcGBCQAgCATAVX6ZBvlKUogP1P3pbmi9bYlFwal9DTPEDCu0s8E06DWqM3TqAw=="
+             })
+           ) == "Encoder can handle binaries that are not strings"
+  end
 end

--- a/test/lib/dynamo/encoder_test.exs
+++ b/test/lib/dynamo/encoder_test.exs
@@ -27,6 +27,12 @@ defmodule ExAws.Dynamo.EncoderTest do
            }
   end
 
+  test "Encoder can handle binaries that are not strings" do
+    assert Encoder.encode(:zlib.zip("Encoder can handle binaries that are not strings")) == %{
+             "B" => "BcGBCQAgCATAVX6ZBvlKUogP1P3pbmi9bYlFwal9DTPEDCu0s8E06DWqM3TqAw=="
+           }
+  end
+
   test "Encoder with structs works properly" do
     user = %Test.User{email: "foo@bar.com", name: "Bob", age: 23, admin: false}
 


### PR DESCRIPTION
Hi,

as stated in the [DynamoDB doc](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.NamingRulesDataTypes.html#HowItWorks.DataTypes) in order to store a value as binary (e.g.: compressed text) you need to first base64 encode it and send it with `%{"B" => "base64encodedtext"}`.

This PR handles the base64 encoding / decoding of a `BitString` that's not  a valid `String`.