### PR TITLE
added ability to specify billing and TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,27 @@
-# ExAws.Dynamo
+# ExAws.DDB (fork of ExAws.Dynamo)
 
-Service module for https://github.com/ex-aws/ex_aws
+A fork of a service module for https://github.com/ex-aws/ex_aws
 
 ##**IMPORTANT - this is a fork!**
 
-This package is a fork of [ex_aws_dynamo](https://hex.pm/packages/ex_aws_dynamo). It supports DynamoDB's new "billing mode" feature, which is critical for our [ecto_adapters_dynamodb](https://hex.pm/packages/ecto_adapters_dynamodb) project.
+This package is a fork of @benwilson512's [ex_aws_dynamo](https://hex.pm/packages/ex_aws_dynamo). It supports DynamoDB's new "billing mode" feature, which is critical for our [ecto_adapters_dynamodb](https://hex.pm/packages/ecto_adapters_dynamodb) project.
 
 Hex requires that, for a package to be published, all of its dependencies must also be Hex packages, rather than sourced from Github/Gitlab, etc.; we (circles-learning-labs) are publishing this fork to Hex for use in our Ecto adapter until these changes have been merged into the original repository and published to Hex.
 
-While circles-learning-labs is taking on the responsibility of publishing this package to Hex, the work itself was done by @taun - view their original fork at https://github.com/taun/ex_aws_dynamo. Thanks, @taun!
+While circles-learning-labs is taking on the responsibility of publishing this package to Hex, the work on the fork itself was done by @taun - view their original fork at https://github.com/taun/ex_aws_dynamo. Thanks, @taun!
 
 **If you need to use ex_aws_dynamo in your project, we highly recommend that you use the original Hex package, as this package may be unexpectedly deleted in the future.**
 
 ## Installation
 
-The package can be installed by adding `ex_aws_dynamo` to your list of dependencies in `mix.exs`
+The package can be installed by adding `ex_aws_ddb` to your list of dependencies in `mix.exs`
 along with `:ex_aws` and your preferred JSON codec / http client
 
 ```elixir
 def deps do
   [
     {:ex_aws, "~> 2.0"},
-    {:ex_aws_dynamo, "~> 2.0"},
+    {:ex_aws_ddb, "~> 2.1"},
     {:poison, "~> 3.0"},
     {:hackney, "~> 1.9"},
   ]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Service module for https://github.com/ex-aws/ex_aws
 
+##**IMPORTANT - this is a fork!**
+
+This package is a fork of [ex_aws_dynamo](https://hex.pm/packages/ex_aws_dynamo). It supports DynamoDB's new "billing mode" feature, which is critical for our [ecto_adapters_dynamodb](https://hex.pm/packages/ecto_adapters_dynamodb) project.
+
+Hex requires that, for a package to be published, all of its dependencies must also be Hex packages, rather than sourced from Github/Gitlab, etc.; we (circles-learning-labs) are publishing this fork to Hex for use in our Ecto adapter until these changes have been merged into the original repository and published to Hex.
+
+While circles-learning-labs is taking on the responsibility of publishing this package to Hex, the work itself was done by @taun - view their original fork at https://github.com/taun/ex_aws_dynamo. Thanks, @taun!
+
+**If you need to use ex_aws_dynamo in your project, we highly recommend that you use the original Hex package, as this package may be unexpectedly deleted in the future.**
+
 ## Installation
 
 The package can be installed by adding `ex_aws_dynamo` to your list of dependencies in `mix.exs`

--- a/mix.exs
+++ b/mix.exs
@@ -1,14 +1,14 @@
 defmodule ExAws.Dynamo.Mixfile do
   use Mix.Project
 
-  @version "2.0.1"
-  @service "dynamo"
-  @url "https://github.com/ex-aws/ex_aws_#{@service}"
-  @name __MODULE__ |> Module.split() |> Enum.take(2) |> Enum.join(".")
+  @version "2.1.0"
+  @service "ddb"
+  @url "https://github.com/circles-learning-labs/ex_aws_#{@service}"
+  @name "ExAws.DDB"
 
   def project do
     [
-      app: :ex_aws_dynamo,
+      app: :ex_aws_ddb,
       version: @version,
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
@@ -22,9 +22,8 @@ defmodule ExAws.Dynamo.Mixfile do
 
   defp package do
     [
-      description: "#{@name} service package",
+      description: "IMPORTANT!!! This package is a fork of https://hex.pm/packages/ex_aws_dynamo - it supports new features of DynamoDB, such as different billing modes - we're publishing this for use in our own https://hex.pm/packages/ecto_adapters_dynamodb. If you need to use ex_aws_dynamo in your project, we highly recommend that you use the original Hex package, as this package may not be maintained and may be unexpectedly deleted in the future.",
       files: ["lib", "config", "mix.exs", "README*"],
-      maintainers: ["Ben Wilson"],
       licenses: ["MIT"],
       links: %{github: @url}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,8 @@
-%{"certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
+%{
+  "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
   "ex_aws": {:hex, :ex_aws, "2.0.0", "9c83ca070b7ddc1079e61a07ba8d97d9c335888881f841bd54691d34fbf0e116", [:mix], [{:configparser_ex, "~> 2.0", [hex: :configparser_ex, repo: "hexpm", optional: true]}, {:hackney, "1.6.3 or 1.6.5 or 1.7.1 or 1.8.6 or ~> 1.9", [hex: :hackney, repo: "hexpm", optional: true]}, {:jsx, "~> 2.8", [hex: :jsx, repo: "hexpm", optional: true]}, {:poison, ">= 1.2.0", [hex: :poison, repo: "hexpm", optional: true]}, {:sweet_xml, "~> 0.6", [hex: :sweet_xml, repo: "hexpm", optional: true]}, {:xml_builder, "~> 0.1.0", [hex: :xml_builder, repo: "hexpm", optional: true]}], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "hackney": {:hex, :hackney, "1.9.0", "51c506afc0a365868469dcfc79a9d0b94d896ec741cfd5bd338f49a5ec515bfe", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
@@ -9,4 +10,5 @@
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
   "sweet_xml": {:hex, :sweet_xml, "0.6.5", "dd9cde443212b505d1b5f9758feb2000e66a14d3c449f04c572f3048c66e6697", [:mix], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
+}


### PR DESCRIPTION
This fork is an unchanged fork of https://github.com/taun/ex_aws_dynamo, which adds support for DDB's billing mode and TTL options.  We've been using this fork in our [Ecto adapter](https://github.com/circles-learning-labs/ecto_adapters_dynamodb), and it is working well - we'd love it if you'd merge taun's work into your project and publish to Hex.

Thank you for all of your hard work!