### PR TITLE
allow expression_attribute_names to be specified in batch_get_item

### DIFF
--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -483,7 +483,9 @@ defmodule ExAws.Dynamo do
       keys: [
         [api_key: "key1"],
         [api_key: "api_key2"]
-      ]
+      ],
+      expression_attribute_names: %{"#api_key" => "api_key"},
+      projection_expression: "#api_key"
     ],
     "Subscriptions" => %{
       keys: [
@@ -503,6 +505,8 @@ defmodule ExAws.Dynamo do
   @type get_item :: [
           {:consistent_read, boolean}
           | {:keys, [primary_key]}
+          | {:expression_attribute_names, expression_attribute_names_vals}
+          | {:projection_expression, binary}
         ]
   @spec batch_get_item(%{table_name => get_item}) :: ExAws.Operation.JSON.t()
   @spec batch_get_item(%{table_name => get_item}, opts :: batch_get_item_opts) :: ExAws.Operation.JSON.t()
@@ -519,7 +523,7 @@ defmodule ExAws.Dynamo do
           |> Map.new()
           |> Map.drop(@special_opts ++ [:keys])
           |> camelize_keys
-          |> build_expression_attribute_names(table_query)
+          |> build_expression_attribute_names(Map.new(table_query))
           |> Map.put("Keys", keys)
 
         Map.put(query, table_name, dynamized_table_query)

--- a/test/lib/dynamo_test.exs
+++ b/test/lib/dynamo_test.exs
@@ -186,7 +186,9 @@ defmodule ExAws.DynamoTest do
         "Subscriptions" => %{"Keys" => [%{id: %{"S" => "id1"}}]},
         "Users" => %{
           "ConsistentRead" => true,
-          "Keys" => [%{api_key: %{"S" => "key1"}}, %{api_key: %{"S" => "api_key2"}}]
+          "Keys" => [%{api_key: %{"S" => "key1"}}, %{api_key: %{"S" => "api_key2"}}],
+          "ExpressionAttributeNames" => %{"#api_key" => "api_key", "#id" => "id"},
+          "ProjectionExpression" => "#id, #api_key"
         }
       }
     }
@@ -198,7 +200,9 @@ defmodule ExAws.DynamoTest do
           keys: [
             [api_key: "key1"],
             [api_key: "api_key2"]
-          ]
+          ],
+          expression_attribute_names: %{"#id" => "id", "#api_key" => "api_key"},
+          projection_expression: "#id, #api_key"
         ],
         "Subscriptions" => %{keys: [%{id: "id1"}]}
       }).data


### PR DESCRIPTION
In the `batch_get_item` call, if the table opts are a keyword list, `expression_attribute_names` are currently dropped from the request. This PR:

- fixes the described bug
- adds a test
- fixes the typespec and docs for `batch_get_item` to show that `expression_attribute_names` and `projection_expression` are supported