### PR TITLE
Add table_exists method

### DIFF
--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -312,14 +312,6 @@ defmodule ExAws.Dynamo do
     request(:describe_table, %{"TableName" => name})
   end
 
-  @doc "Table exists"
-  @spec table_exists?(table_name :: String.t) :: boolean
-  def table_exists?(table_name) do
-    list_tables() |> ExAws.request!
-      |> (fn(r) -> r["TableNames"] end).()
-      |> Enum.member?(table_name)
-  end
-
   @doc "Update Table"
   @spec update_table(name :: binary, attributes :: Keyword.t() | Map.t()) :: ExAws.Operation.JSON.t()
   def update_table(name, attributes) do

--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -312,6 +312,14 @@ defmodule ExAws.Dynamo do
     request(:describe_table, %{"TableName" => name})
   end
 
+  @doc "Table exists"
+  @spec table_exists?(table_name :: String.t) :: boolean
+  def table_exists?(table_name) do
+    list_tables() |> ExAws.request!
+      |> (fn(r) -> r["TableNames"] end).()
+      |> Enum.member?(table_name)
+  end
+
   @doc "Update Table"
   @spec update_table(name :: binary, attributes :: Keyword.t() | Map.t()) :: ExAws.Operation.JSON.t()
   def update_table(name, attributes) do

--- a/lib/ex_aws/dynamo/util.ex
+++ b/lib/ex_aws/dynamo/util.ex
@@ -1,0 +1,16 @@
+defmodule ExAws.Dynamo.Util do
+  @moduledoc """
+  A collection of light weight utility functions
+  """
+
+  @doc "Table exists"
+  @spec table_exists?(table_name :: String.t) :: boolean
+  def table_exists?(table_name) do
+    try do
+      ExAws.Dynamo.describe_table(table_name) |> ExAws.request!
+      true
+    rescue
+      ExAws.Error -> false
+    end
+  end
+end

--- a/test/lib/dynamo/integration_test.exs
+++ b/test/lib/dynamo/integration_test.exs
@@ -19,6 +19,7 @@ defmodule ExAws.DynamoIntegrationTest do
           "TestSeveralUsers",
           TestFoo,
           "test_books",
+          "test_schools",
           "TestUsersWithRange",
           "TestTransactions",
           "TestTransactions2"
@@ -38,6 +39,11 @@ defmodule ExAws.DynamoIntegrationTest do
       test "#create and destroy table" do
         assert {:ok, %{"TableDescription" => %{"TableName" => "Elixir.TestFoo"}}} =
                  Dynamo.create_table(TestFoo, :shard_id, [shard_id: :string], 1, 1) |> ExAws.request()
+      end
+
+      test "#table_exists?" do
+        {:ok, _} = Dynamo.create_table("test_schools", :email, [email: :string], 1, 1) |> ExAws.request()
+        assert Dynamo.table_exists?("test_schools") == true
       end
 
       test "#create table with range" do

--- a/test/lib/dynamo/integration_test.exs
+++ b/test/lib/dynamo/integration_test.exs
@@ -42,8 +42,9 @@ defmodule ExAws.DynamoIntegrationTest do
       end
 
       test "#table_exists?" do
+        assert Dynamo.Util.table_exists?("test_schools") == false
         {:ok, _} = Dynamo.create_table("test_schools", :email, [email: :string], 1, 1) |> ExAws.request()
-        assert Dynamo.table_exists?("test_schools") == true
+        assert Dynamo.Util.table_exists?("test_schools") == true
       end
 
       test "#create table with range" do


### PR DESCRIPTION
## Background

One common task is to check if a Dynamo table already exists. This is a convenient method for that.

## Testing
Snapshot of local test results
![Screen Shot 2019-10-26 at 10 37 39 PM](https://user-images.githubusercontent.com/806135/67629229-3c50c600-f841-11e9-9339-7c8710b8cdb7.png)

