### PR TITLE
Include consistent_read option in scan_opts spec

### DIFF
--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -424,7 +424,8 @@ defmodule ExAws.Dynamo do
   `[:exclusive_start_key, :expression_attribute_names]`
   """
   @type scan_opts :: [
-          {:exclusive_start_key, exclusive_start_key_vals}
+          {:consistent_read, boolean}
+          | {:exclusive_start_key, exclusive_start_key_vals}
           | {:expression_attribute_names, expression_attribute_names_vals}
           | {:expression_attribute_values, expression_attribute_values_vals}
           | {:filter_expression, binary}


### PR DESCRIPTION
Reference: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Scan.html#DDB-Scan-request-ConsistentRead