### PR TITLE
Add table stream config

### DIFF
--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -68,12 +68,14 @@ defmodule ExAws.Dynamo do
   @nested_opts [:exclusive_start_key, :expression_attribute_values, :expression_attribute_names]
   @upcase_opts [:return_values, :return_item_collection_metrics, :select, :total_segments]
   @top_level_update_fields [
-    :global_indexes,
-    :local_indexes,
-    :read_capacity,
-    :write_capacity,
+    :attribute_definitions,
     :billing_mode,
-    :provisioned_throughput
+    :global_indexes,
+    :global_secondary_index_updates,
+    :local_indexes,
+    :provisioned_throughput,
+    :read_capacity,
+    :write_capacity
   ]
   @special_opts @nested_opts ++ @upcase_opts
   @default_billing_mode :provisioned

--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -298,7 +298,7 @@ defmodule ExAws.Dynamo do
   * `billing_mode`: `#{inspect(@default_billing_mode)}`
   * `read_capacity`: `#{@default_read_capacity}`
   * `write_capacity`: `#{@default_write_capacity}`
-  * `streaming_enabled`: `false`
+  * `stream_enabled`: `false`
   """
   @spec create_table(binary, key_schema, key_definitions, create_table_opts) :: JSON.t()
   def create_table(name, key_schema, key_definitions, opts \\ []) do

--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -67,6 +67,14 @@ defmodule ExAws.Dynamo do
 
   @nested_opts [:exclusive_start_key, :expression_attribute_values, :expression_attribute_names]
   @upcase_opts [:return_values, :return_item_collection_metrics, :select, :total_segments]
+  @top_level_update_fields [
+    :global_indexes,
+    :local_indexes,
+    :read_capacity,
+    :write_capacity,
+    :billing_mode,
+    :provisioned_throughput
+  ]
   @special_opts @nested_opts ++ @upcase_opts
   @default_billing_mode :provisioned
   @default_read_capacity 10
@@ -373,6 +381,7 @@ defmodule ExAws.Dynamo do
   def update_table(name, opts) do
     data =
       opts
+      |> take_opts(@top_level_update_fields)
       |> maybe_convert_billing_mode()
       |> camelize_keys(deep: true)
       |> Map.merge(%{"TableName" => name})
@@ -419,7 +428,7 @@ defmodule ExAws.Dynamo do
   end
 
   defp add_table_opt(_, data) do
-    # Other opts are handled in create_table
+    # Other opts are handled in create_table and update_table
     data
   end
 
@@ -971,4 +980,7 @@ defmodule ExAws.Dynamo do
       |> Map.merge(opts)
     )
   end
+
+  defp take_opts(map, keys) when is_map(map), do: Map.take(map, keys)
+  defp take_opts(keyword, keys) when is_list(keyword), do: Keyword.take(keyword, keys)
 end

--- a/test/lib/dynamo_test.exs
+++ b/test/lib/dynamo_test.exs
@@ -177,15 +177,16 @@ defmodule ExAws.DynamoTest do
 
     expected = %{
       "TableName" => "TestUsers",
-      "StreamType" => :keys_only,
-      "StreamEnabled" => true,
-      "StreamSpecification" => %{"StreamEnabled" => true}
+      "StreamSpecification" => %{
+        "StreamEnabled" => true,
+        "StreamViewType" => "KEYS_ONLY"
+      }
     }
 
     assert Dynamo.update_table(
              "TestUsers",
              stream_enabled: true,
-             stream_type: :keys_only
+             stream_view_type: :keys_only
            ).data == expected
   end
 

--- a/test/lib/dynamo_test.exs
+++ b/test/lib/dynamo_test.exs
@@ -121,6 +121,26 @@ defmodule ExAws.DynamoTest do
            ).data == expected
   end
 
+  test "create_table with explicitly disabled stream config" do
+    expected = %{
+      "AttributeDefinitions" => [%{"AttributeName" => :id, "AttributeType" => "S"}],
+      "BillingMode" => "PAY_PER_REQUEST",
+      "KeySchema" => [%{"AttributeName" => :id, "KeyType" => "HASH"}],
+      "StreamSpecification" => %{
+        "StreamEnabled" => false
+      },
+      "TableName" => "TestUsers"
+    }
+
+    assert Dynamo.create_table(
+             "TestUsers",
+             [id: :hash],
+             %{id: :string},
+             billing_mode: :pay_per_request,
+             stream_enabled: false
+           ).data == expected
+  end
+
   test "#update_table" do
     expected = %{"BillingMode" => "PAY_PER_REQUEST", "TableName" => "TestUsers"}
 

--- a/test/lib/dynamo_test.exs
+++ b/test/lib/dynamo_test.exs
@@ -99,6 +99,28 @@ defmodule ExAws.DynamoTest do
            ).data == expected
   end
 
+  test "create_table with stream config" do
+    expected = %{
+      "AttributeDefinitions" => [%{"AttributeName" => :id, "AttributeType" => "S"}],
+      "BillingMode" => "PAY_PER_REQUEST",
+      "KeySchema" => [%{"AttributeName" => :id, "KeyType" => "HASH"}],
+      "StreamSpecification" => %{
+        "StreamEnabled" => true,
+        "StreamViewType" => "KEYS_ONLY"
+      },
+      "TableName" => "TestUsers"
+    }
+
+    assert Dynamo.create_table(
+             "TestUsers",
+             [id: :hash],
+             %{id: :string},
+             billing_mode: :pay_per_request,
+             stream_enabled: true,
+             stream_view_type: :keys_only
+           ).data == expected
+  end
+
   test "#update_table" do
     expected = %{"BillingMode" => "PAY_PER_REQUEST", "TableName" => "TestUsers"}
 
@@ -131,6 +153,19 @@ defmodule ExAws.DynamoTest do
 
     assert Dynamo.update_table("TestUsers",
              provisioned_throughput: [read_capacity_units: 2, write_capacity_units: 3]
+           ).data == expected
+
+    expected = %{
+      "TableName" => "TestUsers",
+      "StreamType" => :keys_only,
+      "StreamEnabled" => true,
+      "StreamSpecification" => %{"StreamEnabled" => true}
+    }
+
+    assert Dynamo.update_table(
+             "TestUsers",
+             stream_enabled: true,
+             stream_type: :keys_only
            ).data == expected
   end
 


### PR DESCRIPTION
I've added the ability to specify stream configuration on table creation and update functions. I also added a generalised form of `create_table` which takes a minimum number of args and an opts at the end for all the extras.