### PR TITLE
Fix attributes data types

### DIFF
--- a/lib/ex_aws/dynamo/encodable.ex
+++ b/lib/ex_aws/dynamo/encodable.ex
@@ -6,9 +6,9 @@ defprotocol ExAws.Dynamo.Encodable do
 end
 
 defimpl ExAws.Dynamo.Encodable, for: Atom do
-  def encode(true, _), do: %{"BOOL" => "true"}
-  def encode(false, _), do: %{"BOOL" => "false"}
-  def encode(nil, _), do: %{"NULL" => "true"}
+  def encode(true, _), do: %{"BOOL" => true}
+  def encode(false, _), do: %{"BOOL" => false}
+  def encode(nil, _), do: %{"NULL" => true}
   def encode(value, _), do: %{"S" => value |> Atom.to_string()}
 end
 

--- a/test/lib/dynamo/encoder_test.exs
+++ b/test/lib/dynamo/encoder_test.exs
@@ -40,7 +40,7 @@ defmodule ExAws.Dynamo.EncoderTest do
     user = %Test.User{email: "foo@bar.com", name: "Bob", age: 23, admin: false}
 
     assert %{
-             "admin" => %{"BOOL" => "false"},
+             "admin" => %{"BOOL" => false},
              "age" => %{"N" => "23"},
              "email" => %{"S" => "foo@bar.com"},
              "name" => %{"S" => "Bob"}
@@ -83,7 +83,7 @@ defmodule ExAws.Dynamo.EncoderTest do
   end
 
   test "encoder nil works" do
-    assert Encoder.encode(nil) == %{"NULL" => "true"}
-    assert Encoder.encode(%{"key" => nil}) == %{"M" => %{"key" => %{"NULL" => "true"}}}
+    assert Encoder.encode(nil) == %{"NULL" => true}
+    assert Encoder.encode(%{"key" => nil}) == %{"M" => %{"key" => %{"NULL" => true}}}
   end
 end

--- a/test/lib/dynamo_test.exs
+++ b/test/lib/dynamo_test.exs
@@ -274,7 +274,7 @@ defmodule ExAws.DynamoTest do
           %{
             "PutRequest" => %{
               "Item" => %{
-                "admin" => %{"BOOL" => "false"},
+                "admin" => %{"BOOL" => false},
                 "age" => %{"N" => "23"},
                 "email" => %{"S" => "foo@bar.com"},
                 "name" => %{"M" => %{"first" => %{"S" => "bob"}, "last" => %{"S" => "bubba"}}}
@@ -303,7 +303,7 @@ defmodule ExAws.DynamoTest do
   test "put item" do
     expected = %{
       "Item" => %{
-        "admin" => %{"BOOL" => "false"},
+        "admin" => %{"BOOL" => false},
         "age" => %{"N" => "23"},
         "email" => %{"S" => "foo@bar.com"},
         "name" => %{"M" => %{"first" => %{"S" => "bob"}, "last" => %{"S" => "bubba"}}}


### PR DESCRIPTION
Hello,
This changes are based on the API specs https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html

The attributes of type BOOL and NULL must have a boolean value instead of a string value.

**Example:**
Current rendered attribute:
```"attr": {"NULL": "true"}```

According to the docs it should be:
```"attr": {"NULL": true}```

While the current implementation works fine on AWS, it doesn't with [localstack](https://github.com/localstack/localstack).

This PR fixes the localstack issues following the AWS API specs.

I hope you find it useful.
