### PR TITLE
Fix `decode_item/1,2` spec

### DIFF
--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -150,8 +150,8 @@ defmodule ExAws.Dynamo do
   |> Dynamo.decode_item(as: User)
   ```
   """
-  @spec decode_item(map()) :: map()
-  @spec decode_item(map(), as: atom) :: map()
+  @spec decode_item(map()) :: map() | [map()]
+  @spec decode_item(map(), as: atom) :: map() | [map()]
   def decode_item(item, opts \\ [])
 
   def decode_item(%{"Items" => items}, opts) do


### PR DESCRIPTION
`decode_item/1,2` can work with `Items` and return a list of `map()`s.
@bernardd please review.