### PR TITLE
Suppress warnings in elixir 1.17

### DIFF
--- a/lib/ex_aws/dynamo/decoder.ex
+++ b/lib/ex_aws/dynamo/decoder.ex
@@ -69,7 +69,7 @@ defmodule ExAws.Dynamo.Decoder do
 
   @doc "Converts a map with binary keys to the specified struct"
   def binary_map_to_struct(bmap, module) do
-    module.__struct__
+    module.__struct__()
     |> Map.from_struct()
     |> Enum.reduce(%{}, fn {k, v}, map ->
       Map.put(map, k, Map.get(bmap, Atom.to_string(k), v))

--- a/test/support/ddb_local.ex
+++ b/test/support/ddb_local.ex
@@ -21,7 +21,7 @@ defmodule DDBLocal do
     if is_nil(port) do
       {:error, "No value provided for :port in config/ddb_local_test.exs."}
     else
-      case :gen_tcp.connect('localhost', port, []) do
+      case :gen_tcp.connect("localhost", port, []) do
         {:ok, _} -> :ok
         {:error, error} -> {:error, error}
       end

--- a/test/support/ddb_local.ex
+++ b/test/support/ddb_local.ex
@@ -21,7 +21,7 @@ defmodule DDBLocal do
     if is_nil(port) do
       {:error, "No value provided for :port in config/ddb_local_test.exs."}
     else
-      case :gen_tcp.connect("localhost", port, []) do
+      case :gen_tcp.connect(~c"localhost", port, []) do
         {:ok, _} -> :ok
         {:error, error} -> {:error, error}
       end


### PR DESCRIPTION
Fix warnings in elixir 1.17 like:

- using map.field notation (without parentheses) to invoke function `Test.User.__struct__()` is deprecated, you must add parentheses instead: remote.function()
- single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead