### PR TITLE
Specify erlang and OTP version in `.tool-versions`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-elixir 1.14.2
+elixir 1.14.2-otp-23
+erlang 23.3.4.6


### PR DESCRIPTION
I updated the asdf `.tool-versions` file to include `erlang` and specify Elixir's OTP version. This makes setting up the project easier for newcomers. _I wasn't sure which Erlang version would be best, so I used the same one from the CI pipeline._

This change was prompted when I encountered the error "Error! Failed to load module 'elixir' because it requires a more recent Erlang/OTP version..." while running `mix test` because I didn't have the correct Erlang version by default. 

