### PR TITLE
Support condition failure return values

### DIFF
--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -775,6 +775,7 @@ defmodule ExAws.Dynamo do
           | {:return_consumed_capacity, return_consumed_capacity_vals}
           | {:return_item_collection_metrics, return_item_collection_metrics_vals}
           | {:return_values, return_values_vals}
+          | {:return_values_on_condition_check_failure, return_values_on_condition_check_failure_vals}
         ]
   @spec delete_item(table_name :: table_name, primary_key :: primary_key) ::
           JSON.t()

--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -747,6 +747,7 @@ defmodule ExAws.Dynamo do
           | {:return_consumed_capacity, return_consumed_capacity_vals}
           | {:return_item_collection_metrics, return_item_collection_metrics_vals}
           | {:return_values, return_values_vals}
+          | {:return_values_on_condition_check_failure, return_values_on_condition_check_failure_vals}
           | {:update_expression, binary}
         ]
   @spec update_item(

--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -66,7 +66,13 @@ defmodule ExAws.Dynamo do
   alias ExAws.Operation.JSON
 
   @nested_opts [:exclusive_start_key, :expression_attribute_values, :expression_attribute_names]
-  @upcase_opts [:return_values, :return_item_collection_metrics, :select, :total_segments]
+  @upcase_opts [
+    :return_values,
+    :return_item_collection_metrics,
+    :return_values_on_condition_check_failure,
+    :select,
+    :total_segments
+  ]
   @top_level_update_fields [
     :attribute_definitions,
     :billing_mode,
@@ -644,6 +650,7 @@ defmodule ExAws.Dynamo do
           | {:return_consumed_capacity, return_consumed_capacity_vals}
           | {:return_item_collection_metrics, return_item_collection_metrics_vals}
           | {:return_values, return_values_vals}
+          | {:return_values_on_condition_check_failure, return_values_on_condition_check_failure_vals}
         ]
   @spec put_item(table_name :: table_name, record :: map()) :: JSON.t()
   @spec put_item(table_name :: table_name, record :: map(), opts :: put_item_opts) ::
@@ -900,6 +907,7 @@ defmodule ExAws.Dynamo do
     |> add_upcased_opt(opts, :return_item_collection_metrics)
     |> add_upcased_opt(opts, :select)
     |> add_upcased_opt(opts, :return_values)
+    |> add_upcased_opt(opts, :return_values_on_condition_check_failure)
     |> add_upcased_opt(opts, :return_consumed_capacity)
     |> camelize_keys
     |> build_special_opts(opts)
@@ -990,6 +998,12 @@ defmodule ExAws.Dynamo do
          {:error, {:aws_unhandled, "TransactionCanceledException" = type, message, %{"CancellationReasons" => reasons}}}
        ) do
     {:error, {type, message, reasons}}
+  end
+
+  # Condition check failures may include the item that failed the check, when
+  # `return_values_on_condition_check_failure` is set to `:all_old`
+  defp error_parser({:error, {:aws_unhandled, "ConditionalCheckFailedException" = type, message, %{"Item" => item}}}) do
+    {:error, {type, message, item}}
   end
 
   defp error_parser(otherwise), do: otherwise

--- a/test/lib/dynamo/integration_test.exs
+++ b/test/lib/dynamo/integration_test.exs
@@ -228,6 +228,61 @@ defmodule ExAws.DynamoIntegrationTest do
         assert Dynamo.decode_item(user_item, as: Test.User) == user
       end
 
+      test "delete item condition failure returns error" do
+        {:ok, _} = Dynamo.create_table(Test.User, :email, [email: :string], 1, 1) |> ExAws.request()
+
+        user = %Test.User{
+          email: "foo@bar.com",
+          name: %{first: "bob", last: "bubba"},
+          age: 25,
+          admin: false
+        }
+
+        # When the condition failure return value is all_old but there is no old
+        # item, the error is returned without an item
+        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
+                 Test.User
+                 |> Dynamo.delete_item([email: user.email],
+                   condition_expression: "email = :email",
+                   expression_attribute_values: [email: "does-not-exist"],
+                   return_values_on_condition_check_failure: :all_old
+                 )
+                 |> ExAws.request()
+
+        {:ok, _} = Dynamo.put_item(Test.User, user) |> ExAws.request()
+
+        # Ensure the default condition failure return value is none and thus no item is returned
+        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
+                 Test.User
+                 |> Dynamo.delete_item([email: user.email],
+                   condition_expression: "email = :email",
+                   expression_attribute_values: [email: "does-not-exist"]
+                 )
+                 |> ExAws.request()
+
+        # When the condition failure return value is none no item is returned
+        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
+                 Test.User
+                 |> Dynamo.delete_item([email: user.email],
+                   condition_expression: "email = :email",
+                   expression_attribute_values: [email: "does-not-exist"],
+                   return_values_on_condition_check_failure: :none
+                 )
+                 |> ExAws.request()
+
+        # When the condition failure return value is all_old the old item is returned
+        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed", user_item}} =
+                 Test.User
+                 |> Dynamo.delete_item([email: user.email],
+                   condition_expression: "email = :email",
+                   expression_attribute_values: [email: "does-not-exist"],
+                   return_values_on_condition_check_failure: :all_old
+                 )
+                 |> ExAws.request()
+
+        assert Dynamo.decode_item(user_item, as: Test.User) == user
+      end
+
       test "transactions work" do
         {:ok, _} = Dynamo.create_table("TestTransactions", :email, [email: :string], 1, 1) |> ExAws.request()
         {:ok, _} = Dynamo.create_table("TestTransactions2", :email, [email: :string], 1, 1) |> ExAws.request()

--- a/test/lib/dynamo/integration_test.exs
+++ b/test/lib/dynamo/integration_test.exs
@@ -118,6 +118,61 @@ defmodule ExAws.DynamoIntegrationTest do
         assert Enum.at(items, 1) == user2
       end
 
+      test "put item condition failure returns error" do
+        {:ok, _} = Dynamo.create_table(Test.User, :email, [email: :string], 1, 1) |> ExAws.request()
+
+        user = %Test.User{
+          email: "foo@bar.com",
+          name: %{first: "bob", last: "bubba"},
+          age: 25,
+          admin: false
+        }
+
+        # When the condition failure return value is all_old but there is no old
+        # item, the error is returned without an item
+        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
+                 Test.User
+                 |> Dynamo.put_item(user,
+                   condition_expression: "email = :email",
+                   expression_attribute_values: [email: "does-not-exist"],
+                   return_values_on_condition_check_failure: :all_old
+                 )
+                 |> ExAws.request()
+
+        {:ok, _} = Dynamo.put_item(Test.User, user) |> ExAws.request()
+
+        # Ensure the default condition failure return value is none and thus no item is returned
+        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
+                 Test.User
+                 |> Dynamo.put_item(user,
+                   condition_expression: "email = :email",
+                   expression_attribute_values: [email: "does-not-exist"]
+                 )
+                 |> ExAws.request()
+
+        # When the condition failure return value is none no item is returned
+        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
+                 Test.User
+                 |> Dynamo.put_item(user,
+                   condition_expression: "email = :email",
+                   expression_attribute_values: [email: "does-not-exist"],
+                   return_values_on_condition_check_failure: :none
+                 )
+                 |> ExAws.request()
+
+        # When the condition failure return value is all_old the old item is returned
+        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed", user_item}} =
+                 Test.User
+                 |> Dynamo.put_item(user,
+                   condition_expression: "email = :email",
+                   expression_attribute_values: [email: "does-not-exist"],
+                   return_values_on_condition_check_failure: :all_old
+                 )
+                 |> ExAws.request()
+
+        assert Dynamo.decode_item(user_item, as: Test.User) == user
+      end
+
       test "transactions work" do
         {:ok, _} = Dynamo.create_table("TestTransactions", :email, [email: :string], 1, 1) |> ExAws.request()
         {:ok, _} = Dynamo.create_table("TestTransactions2", :email, [email: :string], 1, 1) |> ExAws.request()

--- a/test/lib/dynamo/integration_test.exs
+++ b/test/lib/dynamo/integration_test.exs
@@ -118,9 +118,7 @@ defmodule ExAws.DynamoIntegrationTest do
         assert Enum.at(items, 1) == user2
       end
 
-      test "put item condition failure returns error" do
-        {:ok, _} = Dynamo.create_table(Test.User, :email, [email: :string], 1, 1) |> ExAws.request()
-
+      test "condition failure with return_values_on_condition_check_failure specified returns expected error" do
         user = %Test.User{
           email: "foo@bar.com",
           name: %{first: "bob", last: "bubba"},
@@ -128,159 +126,58 @@ defmodule ExAws.DynamoIntegrationTest do
           admin: false
         }
 
-        # When the condition failure return value is all_old but there is no old
-        # item, the error is returned without an item
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
-                 Test.User
-                 |> Dynamo.put_item(user,
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"],
-                   return_values_on_condition_check_failure: :all_old
-                 )
-                 |> ExAws.request()
+        operations = [
+          {"put_item", fn opts -> Dynamo.put_item(Test.User, user, opts) end},
+          {"update_item", fn opts -> Dynamo.update_item(Test.User, [email: user.email], opts) end},
+          {"delete_item", fn opts -> Dynamo.delete_item(Test.User, [email: user.email], opts) end}
+        ]
 
-        {:ok, _} = Dynamo.put_item(Test.User, user) |> ExAws.request()
+        Enum.each(operations, fn {name, operation} ->
+          DDBLocal.delete_test_tables([Test.User])
 
-        # Ensure the default condition failure return value is none and thus no item is returned
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
-                 Test.User
-                 |> Dynamo.put_item(user,
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"]
-                 )
-                 |> ExAws.request()
+          {:ok, _} = Dynamo.create_table(Test.User, :email, [email: :string], 1, 1) |> ExAws.request()
 
-        # When the condition failure return value is none no item is returned
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
-                 Test.User
-                 |> Dynamo.put_item(user,
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"],
-                   return_values_on_condition_check_failure: :none
-                 )
-                 |> ExAws.request()
+          # When the condition failure return value is all_old but there is no old
+          # item, the error is returned without an item
+          assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
+                   operation.(
+                     condition_expression: "email = :email",
+                     expression_attribute_values: [email: "does-not-exist"],
+                     return_values_on_condition_check_failure: :all_old
+                   )
+                   |> ExAws.request()
 
-        # When the condition failure return value is all_old the old item is returned
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed", user_item}} =
-                 Test.User
-                 |> Dynamo.put_item(user,
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"],
-                   return_values_on_condition_check_failure: :all_old
-                 )
-                 |> ExAws.request()
+          {:ok, _} = Dynamo.put_item(Test.User, user) |> ExAws.request()
 
-        assert Dynamo.decode_item(user_item, as: Test.User) == user
-      end
+          # Ensure the default condition failure return value is none and thus no item is returned
+          assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
+                   operation.(
+                     condition_expression: "email = :email",
+                     expression_attribute_values: [email: "does-not-exist"]
+                   )
+                   |> ExAws.request()
 
-      test "update item condition failure returns error" do
-        {:ok, _} = Dynamo.create_table(Test.User, :email, [email: :string], 1, 1) |> ExAws.request()
+          # When the condition failure return value is none, no item is returned
+          assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
+                   operation.(
+                     condition_expression: "email = :email",
+                     expression_attribute_values: [email: "does-not-exist"],
+                     return_values_on_condition_check_failure: :none
+                   )
+                   |> ExAws.request(),
+                 name
 
-        user = %Test.User{
-          email: "foo@bar.com",
-          name: %{first: "bob", last: "bubba"},
-          age: 25,
-          admin: false
-        }
+          # When the condition failure return value is all_old, the old item is returned
+          assert {:error, {"ConditionalCheckFailedException", "The conditional request failed", 123 = user_item}} =
+                   operation.(
+                     condition_expression: "email = :email",
+                     expression_attribute_values: [email: "does-not-exist"],
+                     return_values_on_condition_check_failure: :all_old
+                   )
+                   |> ExAws.request()
 
-        # When the condition failure return value is all_old but there is no old
-        # item, the error is returned without an item
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
-                 Test.User
-                 |> Dynamo.update_item([email: user.email],
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"],
-                   return_values_on_condition_check_failure: :all_old
-                 )
-                 |> ExAws.request()
-
-        {:ok, _} = Dynamo.put_item(Test.User, user) |> ExAws.request()
-
-        # Ensure the default condition failure return value is none and thus no item is returned
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
-                 Test.User
-                 |> Dynamo.update_item([email: user.email],
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"]
-                 )
-                 |> ExAws.request()
-
-        # When the condition failure return value is none no item is returned
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
-                 Test.User
-                 |> Dynamo.update_item([email: user.email],
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"],
-                   return_values_on_condition_check_failure: :none
-                 )
-                 |> ExAws.request()
-
-        # When the condition failure return value is all_old the old item is returned
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed", user_item}} =
-                 Test.User
-                 |> Dynamo.update_item([email: user.email],
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"],
-                   return_values_on_condition_check_failure: :all_old
-                 )
-                 |> ExAws.request()
-
-        assert Dynamo.decode_item(user_item, as: Test.User) == user
-      end
-
-      test "delete item condition failure returns error" do
-        {:ok, _} = Dynamo.create_table(Test.User, :email, [email: :string], 1, 1) |> ExAws.request()
-
-        user = %Test.User{
-          email: "foo@bar.com",
-          name: %{first: "bob", last: "bubba"},
-          age: 25,
-          admin: false
-        }
-
-        # When the condition failure return value is all_old but there is no old
-        # item, the error is returned without an item
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
-                 Test.User
-                 |> Dynamo.delete_item([email: user.email],
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"],
-                   return_values_on_condition_check_failure: :all_old
-                 )
-                 |> ExAws.request()
-
-        {:ok, _} = Dynamo.put_item(Test.User, user) |> ExAws.request()
-
-        # Ensure the default condition failure return value is none and thus no item is returned
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
-                 Test.User
-                 |> Dynamo.delete_item([email: user.email],
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"]
-                 )
-                 |> ExAws.request()
-
-        # When the condition failure return value is none no item is returned
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed"}} =
-                 Test.User
-                 |> Dynamo.delete_item([email: user.email],
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"],
-                   return_values_on_condition_check_failure: :none
-                 )
-                 |> ExAws.request()
-
-        # When the condition failure return value is all_old the old item is returned
-        assert {:error, {"ConditionalCheckFailedException", "The conditional request failed", user_item}} =
-                 Test.User
-                 |> Dynamo.delete_item([email: user.email],
-                   condition_expression: "email = :email",
-                   expression_attribute_values: [email: "does-not-exist"],
-                   return_values_on_condition_check_failure: :all_old
-                 )
-                 |> ExAws.request()
-
-        assert Dynamo.decode_item(user_item, as: Test.User) == user
+          assert Dynamo.decode_item(user_item, as: Test.User) == user
+        end)
       end
 
       test "transactions work" do

--- a/test/lib/dynamo_test.exs
+++ b/test/lib/dynamo_test.exs
@@ -387,6 +387,32 @@ defmodule ExAws.DynamoTest do
     assert Dynamo.update_item("Users", [email: "foo@bar.com"], opts).data == expected
   end
 
+  test "delete item with opts" do
+    expected = %{
+      "Key" => %{"email" => %{"S" => "foo@bar.com"}},
+      "TableName" => "Users",
+      "ConditionExpression" => "email = :email",
+      "ExpressionAttributeNames" => %{"#admin" => "admin"},
+      "ExpressionAttributeValues" => %{":admin" => %{"BOOL" => true}},
+      "ReturnConsumedCapacity" => "TOTAL",
+      "ReturnItemCollectionMetrics" => "SIZE",
+      "ReturnValues" => "ALL_OLD",
+      "ReturnValuesOnConditionCheckFailure" => "ALL_OLD"
+    }
+
+    opts = [
+      condition_expression: "email = :email",
+      expression_attribute_names: %{"#admin" => "admin"},
+      expression_attribute_values: [admin: true],
+      return_consumed_capacity: :total,
+      return_item_collection_metrics: :size,
+      return_values: :all_old,
+      return_values_on_condition_check_failure: :all_old
+    ]
+
+    assert Dynamo.delete_item("Users", [email: "foo@bar.com"], opts).data == expected
+  end
+
   test "update_time_to_live" do
     expected = %{
       "TableName" => "Users",

--- a/test/lib/dynamo_test.exs
+++ b/test/lib/dynamo_test.exs
@@ -359,6 +359,34 @@ defmodule ExAws.DynamoTest do
     assert Dynamo.put_item("Users", user, opts).data == expected
   end
 
+  test "update item with opts" do
+    expected = %{
+      "Key" => %{"email" => %{"S" => "foo@bar.com"}},
+      "TableName" => "Users",
+      "ConditionExpression" => "email = :email",
+      "ExpressionAttributeNames" => %{"#admin" => "admin"},
+      "ExpressionAttributeValues" => %{":admin" => %{"BOOL" => true}},
+      "ReturnConsumedCapacity" => "TOTAL",
+      "ReturnItemCollectionMetrics" => "SIZE",
+      "ReturnValues" => "ALL_OLD",
+      "ReturnValuesOnConditionCheckFailure" => "ALL_OLD",
+      "UpdateExpression" => "SET admin = :admin"
+    }
+
+    opts = [
+      condition_expression: "email = :email",
+      expression_attribute_names: %{"#admin" => "admin"},
+      expression_attribute_values: [admin: true],
+      return_consumed_capacity: :total,
+      return_item_collection_metrics: :size,
+      return_values: :all_old,
+      return_values_on_condition_check_failure: :all_old,
+      update_expression: "SET admin = :admin"
+    ]
+
+    assert Dynamo.update_item("Users", [email: "foo@bar.com"], opts).data == expected
+  end
+
   test "update_time_to_live" do
     expected = %{
       "TableName" => "Users",

--- a/test/lib/dynamo_test.exs
+++ b/test/lib/dynamo_test.exs
@@ -321,6 +321,44 @@ defmodule ExAws.DynamoTest do
     assert Dynamo.put_item("Users", user).data == expected
   end
 
+  test "put item with opts" do
+    expected = %{
+      "Item" => %{
+        "admin" => %{"BOOL" => false},
+        "age" => %{"N" => "23"},
+        "email" => %{"S" => "foo@bar.com"},
+        "name" => %{"M" => %{"first" => %{"S" => "bob"}, "last" => %{"S" => "bubba"}}}
+      },
+      "TableName" => "Users",
+      "ConditionExpression" => "email = :email",
+      "ExpressionAttributeNames" => %{"#admin" => "admin"},
+      "ExpressionAttributeValues" => %{":admin" => %{"BOOL" => true}},
+      "ReturnConsumedCapacity" => "TOTAL",
+      "ReturnItemCollectionMetrics" => "SIZE",
+      "ReturnValues" => "ALL_OLD",
+      "ReturnValuesOnConditionCheckFailure" => "ALL_OLD"
+    }
+
+    user = %Test.User{
+      email: "foo@bar.com",
+      name: %{first: "bob", last: "bubba"},
+      age: 23,
+      admin: false
+    }
+
+    opts = [
+      condition_expression: "email = :email",
+      expression_attribute_names: %{"#admin" => "admin"},
+      expression_attribute_values: [admin: true],
+      return_consumed_capacity: :total,
+      return_item_collection_metrics: :size,
+      return_values: :all_old,
+      return_values_on_condition_check_failure: :all_old
+    ]
+
+    assert Dynamo.put_item("Users", user, opts).data == expected
+  end
+
   test "update_time_to_live" do
     expected = %{
       "TableName" => "Users",


### PR DESCRIPTION
This PR adds support for the `:return_values_on_condition_check_failure` option on the `put_item`, `update_item`, and `delete_item` operations. More specifically, it adds support for returning the old item in the error, which helps determine why a condition check failed. It allows you to compare the current database value with the condition to determine what condition failed.

The most controversial aspect of this change will likely be the addition of a new error structure for the `ConditionalCheckFailedException`. I've included examples below of what the errors look like for various cases. I've tried to make the changes work in such a way that if `return_values_on_condition_check_failure` was never specified (which it shouldn't be, as it's not in the type spec for those functions) the behaviour is unchanged. Only when `return_values_on_condition_check_failure: :all_old` is used does a user now need to worry about a new error format.

All that being said, I understand if you want to avoid changing the error format. However, I suggest at least considering the changes to the type specs and the option parsing for `return_values_on_condition_check_failure`. Those changes fix some dialyzer and parser errors when trying to specify the attribute. With these changes, users can still override the `error_parser` themselves if they need to get access to the item.

### Example Error Cases

**`return_values_on_condition_check_failure: :none` / default / (unchanged behaviour)**

When there is an old item available:

```elixir
{
  "ConditionalCheckFailedException",
  "The conditional request failed"
}
```

When there is no old item available:

```elixir
{
  "ConditionalCheckFailedException",
  "The conditional request failed"
}
```

**`return_values_on_condition_check_failure: :all_old`**

When there is an old item available:

```elixir
{
  "ConditionalCheckFailedException",
  "The conditional request failed",
  %{"admin" => %{"BOOL" => false}, "age" => %{"N" => "25"}, "email" => %{"S" => "foo@bar.com"}, "name" => %{"M" => %{"first" => %{"S" => "bob"}, "last" => %{"S" => "bubba"}}}}
}
```

When there is no old item available:

```elixir
{
  "ConditionalCheckFailedException",
  "The conditional request failed"
}
```

---

_I'm open to any and all other suggestions, so please feel free to leave comments or nitpicks. :)_ 