### PR TITLE
Add :except to derive options

### DIFF
--- a/lib/ex_aws/dynamo/encodable.ex
+++ b/lib/ex_aws/dynamo/encodable.ex
@@ -37,10 +37,10 @@ defimpl ExAws.Dynamo.Encodable, for: Any do
 
   def deriving(module, _struct, options) do
     extractor =
-      if only = options[:only] do
-        quote(do: Map.take(struct, unquote(only)))
-      else
-        quote(do: :maps.remove(:__struct__, struct))
+      cond do
+        only = options[:only] -> quote(do: Map.take(struct, unquote(only)))
+        except = options[:except] -> quote(do: Map.drop(struct, [:__struct__] ++ unquote(except)))
+        true -> quote(do: :maps.remove(:__struct__, struct))
       end
 
     quote do

--- a/test/lib/dynamo/encoder_test.exs
+++ b/test/lib/dynamo/encoder_test.exs
@@ -88,12 +88,14 @@ defmodule ExAws.Dynamo.EncoderTest do
   end
 
   test "encoder skips struct fields that are marked as excepted" do
-    user_except = %Test.ExceptUser{email: "foo@bar.com", name: "Bob", age: 23, secret: "secret information"} |> Encoder.encode_root()
+    user_except =
+      %Test.ExceptUser{email: "foo@bar.com", name: "Bob", age: 23, secret: "secret information"}
+      |> Encoder.encode_root()
 
     assert %{
-      "age" => %{"M" => %{"N" => %{"S" => "23"}}},
-      "email" => %{"M" => %{"S" => %{"S" => "foo@bar.com"}}},
-      "name" => %{"M" => %{"S" => %{"S" => "Bob"}}}
-    } = Encoder.encode_root(user_except)
+             "age" => %{"M" => %{"N" => %{"S" => "23"}}},
+             "email" => %{"M" => %{"S" => %{"S" => "foo@bar.com"}}},
+             "name" => %{"M" => %{"S" => %{"S" => "Bob"}}}
+           } = Encoder.encode_root(user_except)
   end
 end

--- a/test/lib/dynamo/encoder_test.exs
+++ b/test/lib/dynamo/encoder_test.exs
@@ -96,6 +96,6 @@ defmodule ExAws.Dynamo.EncoderTest do
              "age" => %{"M" => %{"N" => %{"S" => "23"}}},
              "email" => %{"M" => %{"S" => %{"S" => "foo@bar.com"}}},
              "name" => %{"M" => %{"S" => %{"S" => "Bob"}}}
-           } = Encoder.encode_root(user_except)
+           } == Encoder.encode_root(user_except)
   end
 end

--- a/test/lib/dynamo/encoder_test.exs
+++ b/test/lib/dynamo/encoder_test.exs
@@ -86,4 +86,14 @@ defmodule ExAws.Dynamo.EncoderTest do
     assert Encoder.encode(nil) == %{"NULL" => true}
     assert Encoder.encode(%{"key" => nil}) == %{"M" => %{"key" => %{"NULL" => true}}}
   end
+
+  test "encoder skips struct fields that are marked as excepted" do
+    user_except = %Test.ExceptUser{email: "foo@bar.com", name: "Bob", age: 23, secret: "secret information"} |> Encoder.encode_root()
+
+    assert %{
+      "age" => %{"M" => %{"N" => %{"S" => "23"}}},
+      "email" => %{"M" => %{"S" => %{"S" => "foo@bar.com"}}},
+      "name" => %{"M" => %{"S" => %{"S" => "Bob"}}}
+    } = Encoder.encode_root(user_except)
+  end
 end

--- a/test/support/mock_models.ex
+++ b/test/support/mock_models.ex
@@ -17,3 +17,8 @@ defmodule Test.Nested do
   @derive {ExAws.Dynamo.Encodable, only: [:items]}
   defstruct items: [], secret: nil
 end
+
+defmodule Test.ExceptUser do
+  @derive {ExAws.Dynamo.Encodable, except: [:secret]}
+  defstruct [:email, :name, :age, :secret]
+end

--- a/test/support/mock_models.ex
+++ b/test/support/mock_models.ex
@@ -19,6 +19,7 @@ defmodule Test.Nested do
 end
 
 defmodule Test.ExceptUser do
+  @moduledoc false
   @derive {ExAws.Dynamo.Encodable, except: [:secret]}
   defstruct [:email, :name, :age, :secret]
 end


### PR DESCRIPTION
This PR adds `:except` option to the macro deriving, to allow specifying which fields of a struct shouldn't be included when it's being encoded. It would be used in a similar way to `:only`
`@derive {ExAws.Dynamo.Encodable, except: [:secret]}`