### PR TITLE
Fix integration tests

### DIFF
--- a/test/lib/dynamo/integration_test.exs
+++ b/test/lib/dynamo/integration_test.exs
@@ -202,7 +202,7 @@ defmodule ExAws.DynamoIntegrationTest do
           admin: true
         }
 
-        assert {:error, {"TransactionCanceledException", _}} =
+        assert {:error, {"TransactionCanceledException", _, _}} =
                  Dynamo.transact_write_items(
                    put: {"TestTransactions", user2},
                    condition_check:

--- a/test/lib/dynamo/integration_test.exs
+++ b/test/lib/dynamo/integration_test.exs
@@ -168,7 +168,7 @@ defmodule ExAws.DynamoIntegrationTest do
                  name
 
           # When the condition failure return value is all_old, the old item is returned
-          assert {:error, {"ConditionalCheckFailedException", "The conditional request failed", 123 = user_item}} =
+          assert {:error, {"ConditionalCheckFailedException", "The conditional request failed", user_item}} =
                    operation.(
                      condition_expression: "email = :email",
                      expression_attribute_values: [email: "does-not-exist"],


### PR DESCRIPTION
Fixes two broken integration tests.

The transaction test is not pattern matching on the correct error format. The condition check test has a match on an incorrect value.

I would have expected CI to catch these. However, it appears the CI runner is not running the integration tests. This is likely because the `config/ddb_local_test.exs` file must be manually created to run those tests. I am happy to look into this and open another PR if they are supposed to be running.