### PR TITLE
Fix typespec of primary_key to allow numbers

### DIFF
--- a/lib/ex_aws/dynamo.ex
+++ b/lib/ex_aws/dynamo.ex
@@ -94,7 +94,8 @@ defmodule ExAws.Dynamo do
   ######################
 
   @type table_name :: binary
-  @type primary_key :: [{atom, binary}] | %{atom => binary}
+  @type primary_key_val :: number | binary
+  @type primary_key :: [{atom, primary_key_val}] | %{atom => primary_key_val}
   @type exclusive_start_key_vals :: [{atom, binary}] | %{atom => binary}
   @type expression_attribute_names_vals :: %{binary => binary}
   @type expression_attribute_values_vals ::


### PR DESCRIPTION
AWS allows numbers (integer and float) to be used in the primary key, while the current spec restricts it to strings.

To reproduce, the following one liner produces the dialyzer warning:

    def hello() do
      ExAws.Dynamo.get_item("table", [{:my_key, 1}])
    end